### PR TITLE
Adds README.md to chef generate repo example cookbook

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/repo/cookbooks/example/README.md
+++ b/lib/chef-dk/skeletons/code_generator/files/default/repo/cookbooks/example/README.md
@@ -1,0 +1,27 @@
+# Example
+
+An example cookbook
+
+## Requirements
+
+### Platform:
+
+*No platforms defined*
+
+### Cookbooks:
+
+*No dependencies defined*
+
+## Attributes
+
+* `node['example']['name']` -  Defaults to `Sam Doe`.
+
+## Recipes
+
+* example::default
+
+## License and Maintainer
+
+Maintainer::  (<>)
+
+License:: All rights reserved


### PR DESCRIPTION
Foodcritic says a cookbook needs a `README.md`. Let us give the example cookbook one. With this addition the result of `chef generate repo example && chef exec foodcritic example/cookbooks/` passes without Foodcritic complaining `FC011: Missing README in markdown format: cma_api_ops/cookbooks/example/README.md:1`

This example `README.md` very nearly the kind generated by the knife-cookbook-doc plugin.